### PR TITLE
Fix duplicate message rendering & stale AI responses in BotUI chat flow

### DIFF
--- a/public/botui.html
+++ b/public/botui.html
@@ -78,14 +78,6 @@
           userEmail = email;
           userName = name;
 
-          console.log('[BotUI] Auth data received:', {
-            hasToken: !!bearerToken,
-            sessionId,
-            userId,
-            userEmail,
-            userName,
-          });
-
           if (!conversationStarted) {
             startConversation();
           }
@@ -98,111 +90,49 @@
 
       async function startConversation() {
         if (!bearerToken || !sessionId) {
-          console.warn('[BotUI] Missing required auth data');
           await botui.message.add({
-            content: '⚠️ Authentication required. Please log in and try again.',
+            content: '⚠️ You need to be logged in to use this chat.',
           });
           return;
         }
 
         conversationStarted = true;
 
-        // Generate unique chat session ID
         const chatSessionId = generateChatSessionId();
 
-        // Show loading message
-        await botui.message.add({
-          content: '⏳ Connecting to OptiFit assistant...',
-        });
+        await botui.message.add({ content: '⏳ Connecting to SMYM assistant...' });
+
+        const initialPayload = {
+          session_id: chatSessionId,
+          user_session_id: sessionId,
+          user_id: userId,
+          user_email: userEmail,
+          user_name: userName,
+          user_message: `Hello, I'm ${userName || 'a user'} and I would like to start a conversation`,
+          source: 'optifit-site',
+          timestamp: new Date().toISOString(),
+        };
 
         try {
-          const response = await fetch(
-            'https://backend.scottmakesyoumove.com/api/v1/chatbot/initiate',
-            {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${bearerToken}`,
-              },
-              body: JSON.stringify({
-                session_id: chatSessionId, // Unique chat session
-                user_session_id: sessionId, // Keycloak user session ID
-                user_id: userId, // User identifier
-                user_email: userEmail, // User email
-                user_name: userName, // User name
-                user_message: `Hello, I'm ${userName || 'a user'} and I would like to start a conversation`,
-                source: 'optifit-site',
-                timestamp: new Date().toISOString(),
-              }),
+          // Fire the initial request
+          await fetch('https://backend.scottmakesyoumove.com/api/v1/chatbot/initiate', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${bearerToken}`,
             },
-          );
-
-          if (!response.ok) {
-            const errorText = await response.text();
-            console.error('[BotUI] API Error:', response.status, errorText);
-
-            // Remove loading message and show error
-            botui.message.removeAll();
-            await botui.message.add({
-              content: `⚠️ Connection failed (${response.status}). Please try again later.`,
-            });
-            return;
-          }
-
-          const data = await response.json(); // this comes via Backend from Zapier
-          console.log('[BotUI] Success response:', data);
-
-          // Remove loading message
-          botui.message.removeAll();
-
-          // Display personalized welcome message
-          const welcomeMessage =
-            data.message ||
-            `👋 Hello ${userName || 'there'}! I'm your OptiFit assistant. How can I help you today?`;
-
-          await botui.message.add({
-            content: welcomeMessage,
+            body: JSON.stringify(initialPayload),
           });
 
-          // Start chat loop with the chat session ID
-          startChatLoop(chatSessionId);
-        } catch (error) {
-          console.error('[BotUI] Network error:', error);
+          // Wait until Zapier's response is ready — poll until ai_response arrives
+          let aiResponse = null;
+          const maxAttempts = 20;
+          let attempts = 0;
 
-          // Remove loading message and show error
-          botui.message.removeAll();
-          await botui.message.add({
-            content: '⚠️ Network error. Please check your connection and try again.',
-          });
-        }
-      }
-
-      async function startChatLoop(chatSessionId) {
-        while (true) {
-          try {
-            // Get user input
-            const userInput = await botui.action.text({
-              action: {
-                placeholder: 'Type your message...',
-              },
-            });
-
-            if (!userInput.value?.trim()) continue;
-
-            // Display user message
-            await botui.message.add({
-              content: userInput.value,
-              human: true,
-            });
-
-            // Show typing indicator
-            const typingMessage = await botui.message.add({
-              content: '💭 Thinking...',
-            });
-
-            // Send to API with session context
-            const response = await fetch(
-              'https://backend.scottmakesyoumove.com/api/v1/chatbot/response',
+          while (!aiResponse && attempts < maxAttempts) {
+            await new Promise((resolve) => setTimeout(resolve, 1000)); // 1s delay
+            const check = await fetch(
+              'https://backend.scottmakesyoumove.com/api/v1/chatbot/initiate', // same endpoint for polling
               {
                 method: 'POST',
                 headers: {
@@ -210,38 +140,139 @@
                   Authorization: `Bearer ${bearerToken}`,
                 },
                 body: JSON.stringify({
-                  session_id: chatSessionId, // Chat session ID
-                  user_session_id: sessionId, // User session ID
-                  user_id: userId, // User identifier
-                  user_message: userInput.value,
-                  source: 'optifit-site',
-                  timestamp: new Date().toISOString(),
+                  ...initialPayload,
+                  user_message: '__PING__', // dummy trigger so Zapier ignores it
                 }),
               },
             );
 
-            // Remove typing indicator
-            botui.message.remove(typingMessage.id);
+            const data = await check.json();
+            if (data.ai_response && !data.ai_response.includes('⚠️ No response')) {
+              aiResponse = data.ai_response;
+              break;
+            }
+
+            attempts++;
+          }
+
+          botui.message.removeAll();
+
+          await botui.message.add({
+            content:
+              aiResponse ||
+              `👋 Hi ${userName}, I'm SMYM, your OptiFit assistant. How can I help you today?`,
+          });
+
+          startChatLoop(chatSessionId);
+        } catch (err) {
+          console.error('[BotUI] Initial conversation failed:', err);
+          botui.message.removeAll();
+          await botui.message.add({
+            content: '⚠️ Connection error. Please try again later.',
+          });
+        }
+      }
+
+      async function startChatLoop(chatSessionId) {
+        console.log('[BotUI] Chat loop started');
+
+        let isWaitingForResponse = false;
+        let lastAiResponse = null;
+
+        while (true) {
+          if (isWaitingForResponse) {
+            await new Promise((r) => setTimeout(r, 250));
+            continue;
+          }
+
+          // Step 1: Get user input
+          const userInput = await botui.action.text({
+            action: {
+              placeholder: 'Type your message...',
+            },
+          });
+
+          const message = userInput.value?.trim();
+          if (!message) continue;
+
+          isWaitingForResponse = true;
+
+          // Step 2: Show thinking animation
+          const thinking = await botui.message.add({
+            content: '💭 Thinking...',
+          });
+
+          try {
+            const payload = {
+              session_id: chatSessionId,
+              user_session_id: sessionId,
+              user_id: userId,
+              user_message: message,
+              source: 'optifit-site',
+              timestamp: new Date().toISOString(),
+            };
+
+            // Step 3: Send user message to Zapier via backend
+            await fetch('https://backend.scottmakesyoumove.com/api/v1/chatbot/initiate', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${bearerToken}`,
+              },
+              body: JSON.stringify(payload),
+            });
+
+            // Step 4: Wait for Zapier to process (~3-5 seconds)
+            await new Promise((resolve) => setTimeout(resolve, 4000));
+
+            // Step 5: Re-fetch the same message to get the AI response
+            const response = await fetch(
+              'https://backend.scottmakesyoumove.com/api/v1/chatbot/initiate',
+              {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Authorization: `Bearer ${bearerToken}`,
+                },
+                body: JSON.stringify(payload), // same as original payload
+              },
+            );
+
+            botui.message.remove(thinking.id);
 
             if (!response.ok) {
+              console.warn('[BotUI] Non-200 response from server');
               await botui.message.add({
                 content: '⚠️ Sorry, I encountered an error. Please try again.',
               });
+              isWaitingForResponse = false;
               continue;
             }
 
             const data = await response.json();
 
-            // Display bot response
+            // Step 6: Deduplicate if AI response is same as last one
+            if (!data.ai_response || data.ai_response === lastAiResponse) {
+              console.warn('[BotUI] Skipping duplicate or empty response');
+              isWaitingForResponse = false;
+              continue;
+            }
+
+            lastAiResponse = data.ai_response;
+
+            // Step 7: Show AI response
             await botui.message.add({
-              content: data.message || "I apologize, but I don't have a response for that.",
+              content: data.ai_response,
             });
-          } catch (error) {
-            console.error('[BotUI] Chat error:', error);
+          } catch (err) {
+            console.error('[BotUI] Chat error:', err);
+            botui.message.remove(thinking.id);
             await botui.message.add({
               content: '⚠️ Something went wrong. Please try again.',
             });
           }
+
+          isWaitingForResponse = false;
         }
       }
 


### PR DESCRIPTION
This PR resolves issues in the chat widget where:

- User input messages were being rendered multiple times.
- AI responses were showing up out of sync with the user's latest question.
- The chatbot sometimes required users to repeat their question to get a relevant answer.

**Key Changes**
- Refactored `startConversation()` to properly wait for Zapier's welcome response before beginning the chat loop.
- Updated `startChatLoop()` to:
  - Prevent multiple overlapping message sends using `isWaitingForResponse`.
  - Introduce a delay (4s) after sending the user message to allow Zapier to generate a response.
  - Fetch the response using the same payload to avoid triggering new AI processing.
  - Deduplicate AI responses using a `lastAiResponse` cache.

**Notes**
While the current approach is stable and avoids duplicate/stale responses, it introduces noticeable latency due to the fixed 4-second delay. This is a frontend-only workaround due to current constraints with BE & Zapier.