### PR TITLE
Load Session Data on Page and Inject into Video Player

### DIFF
--- a/src/components/SmartVideoPlayer.tsx
+++ b/src/components/SmartVideoPlayer.tsx
@@ -11,6 +11,9 @@ interface SmartVideoPlayerProps {
   sessionId?: string;
   accountId?: string;
   accessToken?: string;
+  sessionStartTime?: string | null;
+  sessionStatus?: string | null;
+  sessionExecutionTime?: string | null;
 }
 
 const SmartVideoPlayer: React.FC<SmartVideoPlayerProps> = ({


### PR DESCRIPTION
Introduces server-side fetching of session data from the backend API. Passes it to the SmartVideoPlayer component for session-specific playback, status handling, and tracking.

### What's Changed
- Server-side Fetch: 
  - Fetched session metadata from `https://backend.scottmakesyoumove.com/api/v1/account/{accountId}/sessions/{sessionId}` using authenticated headers and no-store caching.

- Graceful error management around the fetch:
  - Prevents hard crashes
  - Logs errors to the console
  - Falls back to null values if fetch fails

- SmartVideoPlayer Updates for session-specific props:
  - `sessionVideoUrl` (used instead of static CMS fallback)
  - `sessionStatus`, `sessionStartTime`, `sessionExecutionTime`

- Code Cleanups:
  - Updated `params` typing to align with Next.js `^15.3.1` (no `Promise`).
  - Modularized the session data structure to handle partial or missing fields.