### PR TITLE
Improve session timing and user feedback across Watch Page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -120,13 +120,15 @@ const AboutPage = async () => {
                       section.imagePosition === 'left' ? 'order-1 md:order-1' : 'order-1 md:order-2'
                     }`}
                   >
-                    <Image
-                      src={section.image.url}
-                      alt={section.image.alt}
-                      width={section.image.width}
-                      height={section.image.height}
-                      className="rounded-lg shadow-md w-full max-w-md mx-auto object-contain"
-                    />
+                    {section.image && (
+                      <Image
+                        src={section.image.url}
+                        alt={section.image.alt}
+                        width={section.image.width}
+                        height={section.image.height}
+                        className="rounded-lg shadow-md w-full max-w-md mx-auto object-contain"
+                      />
+                    )}
                   </div>
 
                   <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -248,13 +248,15 @@ const Home = async () => {
                     </div>
                   </div>
                   <div className="w-full md:w-1/2">
-                    <Image
-                      src={section.image.url}
-                      alt={section.image.alt}
-                      width={section.image.width}
-                      height={section.image.height}
-                      className="rounded-lg shadow-md w-full max-w-md mx-auto object-contain"
-                    />
+                    {section.image && (
+                      <Image
+                        src={section.image.url}
+                        alt={section.image.alt}
+                        width={section.image.width}
+                        height={section.image.height}
+                        className="rounded-lg shadow-md w-full max-w-md mx-auto object-contain"
+                      />
+                    )}
                   </div>
                 </div>
               </section>

--- a/src/app/progress-form/ProgressFormSection.tsx
+++ b/src/app/progress-form/ProgressFormSection.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import ProgressForm from './ProgressForm';
 
 type Props = {
@@ -10,22 +9,7 @@ type Props = {
 const ProgressFormSection: React.FC<Props> = ({ accessToken, accountId, type }) => {
   return (
     <section className="max-w-screen px-6 py-16">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-10 items-center">
-        <div>
-          <ProgressForm accessToken={accessToken} accountId={accountId} type={type} />
-        </div>
-
-        <div className="w-full h-full rounded-2xl overflow-hidden">
-          <Image
-            src="https://placehold.co/800x600.png"
-            alt="User reviewing data"
-            width={800}
-            height={600}
-            className="object-cover w-full h-full"
-            priority
-          />
-        </div>
-      </div>
+      <ProgressForm accessToken={accessToken} accountId={accountId} type={type} />
     </section>
   );
 };

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -6,6 +6,7 @@ import { executeQuery } from '@/lib/datocms/executeQuery';
 import { graphql } from '@/lib/datocms/graphql';
 import requireAuth from '@/lib/auth/requireAuth';
 import { getWeeklyQuote } from '@/utils/getWeeklyQuote';
+import { getNextBreakTime } from '@/utils/getNextBreakTime';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -44,26 +45,6 @@ const query = graphql<string, never>(`
     }
   }
 `);
-
-const getNextBreakTime = () => {
-  const breakTimes = ['10:00', '13:30', '15:00'];
-  const now = new Date();
-  const currentMinutes = now.getHours() * 60 + now.getMinutes();
-
-  for (const timeStr of breakTimes) {
-    const [h, m] = timeStr.split(':').map(Number);
-    const breakMinutes = h * 60 + m;
-
-    if (breakMinutes > currentMinutes) {
-      return timeStr;
-    }
-  }
-
-  // Wrap to the first break time of next day
-  return breakTimes[0];
-};
-
-const nextBreakTime = getNextBreakTime();
 
 export default async function WatchPage({ params }: PageProps) {
   const { id: sessionId } = await params;
@@ -145,7 +126,7 @@ export default async function WatchPage({ params }: PageProps) {
           <div className="flex justify-start">
             <TimeDisplay
               nextBreakPrefix={movementBreak.reminderPrefix}
-              nextBreakTime={nextBreakTime}
+              nextBreakTime={getNextBreakTime()}
             />
           </div>
         </section>

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -54,12 +54,14 @@ export default async function WatchPage({ params }: PageProps) {
 
   let sessionData: {
     sessionStartTime: string | null;
+    sessionStartDisplay?: string | null;
     sessionExecutionTime: string | null;
     exerciseType: string | null;
     sessionStatus: string | null;
     sessionVideoUrl: string | null;
   } = {
     sessionStartTime: null,
+    sessionStartDisplay: null,
     sessionExecutionTime: null,
     exerciseType: null,
     sessionStatus: null,
@@ -83,15 +85,17 @@ export default async function WatchPage({ params }: PageProps) {
     }
 
     const data = await sessionRes.json();
-    console.log('🚀 ~ WatchPage ~ data:', data);
-    const timePart = data.sessionStartTime.split('T')[1];
-    const sessionHHMM = timePart.slice(0, 5);
-
-    // For session start time displays
-    const sessionStartTime = sessionHHMM;
+    const sessionStart = new Date(data.sessionStartTime);
+    const sessionStartTime = sessionStart.toISOString();
+    const sessionStartDisplay = sessionStart.toLocaleTimeString('nl-NL', {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: 'Europe/Amsterdam',
+    });
 
     sessionData = {
       sessionStartTime,
+      sessionStartDisplay,
       sessionExecutionTime: data.sessionExecutionTime ?? null,
       exerciseType: data.exerciseType ?? null,
       sessionStatus: data.sessionStatus ?? null,
@@ -147,6 +151,7 @@ export default async function WatchPage({ params }: PageProps) {
                 accountId={accountId}
                 accessToken={accessToken}
                 sessionStartTime={sessionData.sessionStartTime}
+                sessionStartDisplay={sessionData.sessionStartDisplay}
                 sessionStatus={sessionData.sessionStatus}
                 sessionExecutionTime={sessionData.sessionExecutionTime}
               />

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -83,6 +83,7 @@ export default async function WatchPage({ params }: PageProps) {
     }
 
     const data = await sessionRes.json();
+    console.log('🚀 ~ WatchPage ~ data:', data);
     const timePart = data.sessionStartTime.split('T')[1];
     const sessionHHMM = timePart.slice(0, 5);
 

--- a/src/components/SmartVideoPlayer.tsx
+++ b/src/components/SmartVideoPlayer.tsx
@@ -247,13 +247,6 @@ const SmartVideoPlayer: React.FC<SmartVideoPlayerProps> = ({
             </>
           )}
 
-          {sessionOverdue && (
-            <p className="text-lg text-gray-900 font-medium text-center">
-              You finished your <strong>{sessionStartDisplay ?? ''}</strong> session, but it was too
-              late to count toward the leaderboard.
-            </p>
-          )}
-
           <a
             href="/leaderboard"
             className="bg-blue-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 transition"

--- a/src/components/SmartVideoPlayer.tsx
+++ b/src/components/SmartVideoPlayer.tsx
@@ -38,6 +38,8 @@ const SmartVideoPlayer: React.FC<SmartVideoPlayerProps> = ({
   sessionStartTime,
   sessionStatus,
 }) => {
+  console.log('🚀 ~ SmartVideoPlayer ~ sessionStartTime:', sessionStartTime);
+  console.log('🚀 ~ SmartVideoPlayer ~ sessionStatus:', sessionStatus);
   const playerRef = useRef<ReactPlayer>(null);
 
   const [progress, setProgress] = useState(0);
@@ -97,6 +99,7 @@ const SmartVideoPlayer: React.FC<SmartVideoPlayerProps> = ({
       );
 
       const data = await res.json();
+      console.log('🚀 ~ markAsWatched ~ data:', data);
 
       if (!res.ok) {
         const errorMsg = data?.message || 'An error occurred while marking the video as watched.';

--- a/src/components/SmartVideoPlayer.tsx
+++ b/src/components/SmartVideoPlayer.tsx
@@ -11,6 +11,7 @@ interface SmartVideoPlayerProps {
   accountId?: string;
   accessToken?: string;
   sessionStartTime?: string | null;
+  sessionStartDisplay?: string | null;
   sessionStatus?: string | null;
   sessionExecutionTime?: string | null;
 }
@@ -36,10 +37,9 @@ const SmartVideoPlayer: React.FC<SmartVideoPlayerProps> = ({
   accountId,
   accessToken,
   sessionStartTime,
+  sessionStartDisplay,
   sessionStatus,
 }) => {
-  console.log('🚀 ~ SmartVideoPlayer ~ sessionStartTime:', sessionStartTime);
-  console.log('🚀 ~ SmartVideoPlayer ~ sessionStatus:', sessionStatus);
   const playerRef = useRef<ReactPlayer>(null);
 
   const [progress, setProgress] = useState(0);
@@ -65,14 +65,17 @@ const SmartVideoPlayer: React.FC<SmartVideoPlayerProps> = ({
     if (!active) {
       setSessionOverdue(true);
       setVideoDeadlineMessage(
-        "⏱ This session has expired. You had 1 hour to complete it. You can still watch the video, but it won't count toward the leaderboard.",
+        `⏱ This ${sessionStartDisplay ?? ''} session has expired. 
+       You had 1 hour to complete it. 
+       You can still watch the video, but it won't count toward the leaderboard.`,
       );
     } else {
       setVideoDeadlineMessage(
-        `✅ You have until ${until} to complete this video. Completion will count toward the leaderboard.`,
+        `✅ This ${sessionStartDisplay ?? ''} session is active. 
+       You have until ${until} to complete it. Completion will count toward the leaderboard.`,
       );
     }
-  }, [sessionStartTime]);
+  }, [sessionStartTime, sessionStartDisplay]);
 
   const showToast = (
     title: string,
@@ -220,14 +223,21 @@ const SmartVideoPlayer: React.FC<SmartVideoPlayerProps> = ({
             <>
               <div
                 className="animate-bounce bg-green-600 text-white px-4 py-2 rounded-full shadow-lg text-2xl font-semibold"
-                aria-label="Video completed and counted toward leaderboard"
+                aria-label={`Video completed for your ${sessionStartDisplay ?? ''} session`}
               >
                 🏅
               </div>
-              <p className="text-lg text-gray-900 font-medium">
-                Nice work on completing the video!
+              <p className="text-lg text-gray-900 font-medium text-center">
+                Nice work on completing your <strong>{sessionStartDisplay ?? ''}</strong> session!
               </p>
             </>
+          )}
+
+          {sessionOverdue && (
+            <p className="text-lg text-gray-900 font-medium text-center">
+              You finished your <strong>{sessionStartDisplay ?? ''}</strong> session, but it was too
+              late to count toward the leaderboard.
+            </p>
           )}
 
           <a

--- a/src/utils/getNextBreakTime.ts
+++ b/src/utils/getNextBreakTime.ts
@@ -1,0 +1,23 @@
+// MVP assumption: Netherlands is currently in UTC+2 (CEST)
+// This will need to change to UTC+1 when daylight savings ends
+const breakTimes = ['10:00', '13:30', '15:00'];
+const timezoneOffsetMinutes = 120; // 2 * 60 = 120 minutes
+
+export const getNextBreakTime = (): string => {
+  const now = new Date();
+
+  const nlTime = new Date(now.getTime() + timezoneOffsetMinutes * 60 * 1000);
+  const currentMinutes = nlTime.getHours() * 60 + nlTime.getMinutes();
+
+  let nextBreak = breakTimes[0];
+  for (const time of breakTimes) {
+    const [h, m] = time.split(':').map(Number);
+    const breakMinutes = h * 60 + m;
+
+    if (breakMinutes > currentMinutes) {
+      nextBreak = time;
+      break;
+    }
+  }
+  return nextBreak;
+};

--- a/src/utils/getNextBreakTime.ts
+++ b/src/utils/getNextBreakTime.ts
@@ -1,23 +1,30 @@
-// MVP assumption: Netherlands is currently in UTC+2 (CEST)
-// This will need to change to UTC+1 when daylight savings ends
 const breakTimes = ['10:00', '13:30', '15:00'];
-const timezoneOffsetMinutes = 120; // 2 * 60 = 120 minutes
 
 export const getNextBreakTime = (): string => {
   const now = new Date();
 
-  const nlTime = new Date(now.getTime() + timezoneOffsetMinutes * 60 * 1000);
-  const currentMinutes = nlTime.getHours() * 60 + nlTime.getMinutes();
+  // Format current time in NL timezone
+  const formatter = new Intl.DateTimeFormat('nl-NL', {
+    timeZone: 'Europe/Amsterdam',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
 
-  let nextBreak = breakTimes[0];
+  const parts = formatter.formatToParts(now);
+  const hours = Number(parts.find((p) => p.type === 'hour')?.value ?? 0);
+  const minutes = Number(parts.find((p) => p.type === 'minute')?.value ?? 0);
+  const currentMinutes = hours * 60 + minutes;
+
   for (const time of breakTimes) {
     const [h, m] = time.split(':').map(Number);
     const breakMinutes = h * 60 + m;
 
     if (breakMinutes > currentMinutes) {
-      nextBreak = time;
-      break;
+      return time;
     }
   }
-  return nextBreak;
+
+  // All breaks passed then return tomorrow's first break
+  return breakTimes[0];
 };


### PR DESCRIPTION
### Session handling

- Preserve full ISO `sessionStartTime` from backend (no more `HH:mm` stripping)
- Add `sessionStartDisplay` for clean “HH:mm” display in UI
- Refactor `SmartVideoPlayer` state:
  - `watchedState` → only true when session is completed in time
  - `sessionOverdue` → true when session expired (regardless of watch progress)
- Update `markAsWatched` to prevent conflicting states (no more duplicate messages)
- Improve success/overdue messages with clear session context (e.g., “15:00 session”)

### Break time logic
- Refactor `getNextBreakTime` to use Europe/Amsterdam timezone (DST-safe)
- Remove brittle manual +120min offset
- Return tomorrow’s first break when all of today’s slots are passed