### PR TITLE
Session Fixes

### DIFF
--- a/docs/flow/sessions.md
+++ b/docs/flow/sessions.md
@@ -1,8 +1,11 @@
 # 🎥 Session Video Flow & Behavior
+
 This explains how the Watch Page (`/watch/:sessionId`) and the `SmartVideoPlayer` work together with the backend API to handle workout sessions, video playback, and leaderboard eligibility.
 
 ## 🔄 End-to-End Flow
+
 1. User Entry
+
    - User receives an email link to `/watch/:sessionId`.
    - Navigates to the page.
 
@@ -10,9 +13,10 @@ This explains how the Watch Page (`/watch/:sessionId`) and the `SmartVideoPlayer
    - `page.tsx` checks if the user is authenticated.
    - If not → redirect to login → then back to `/watch/:sessionId`.
    - If authenticated → fetch session details from
-GET `/api/v1/account/{accountId}/sessions/{sessionId}`.
+     GET `/api/v1/account/{accountId}/sessions/{sessionId}`.
 
 Data returned (from SessionDto):
+
 ```json
 {
   "sessionStartTime": "2025-09-22T10:00:00.000+0200",
@@ -24,6 +28,7 @@ Data returned (from SessionDto):
 ```
 
 3. Rendering
+
    - Page renders three sections:
      - ⏱ Movement break (from CMS)
      - 🎥 Exercise video (`SmartVideoPlayer`)
@@ -38,24 +43,27 @@ Data returned (from SessionDto):
      - Calls `PUT /sessions/{id}` to update session status when complete.
 
 ## 🟩 Session Status & UI States
-| **`sessionStatus`** | **Frontend UI**                                                        | **Eligibility**             |
-| --------------------------- | ---------------------------------------------------------------------- | --------------------------- |
-| `NEW` + within 1h           | Green ✅ banner, video player, “Mark as Done” button (enabled at ≥ 90%) | ✅ Counts toward leaderboard |
-| `NEW` + >1h expired         | Red ⏱ banner, video only (no button)                                   | ❌ No points                 |
-| `COMPLETED`                 | 🏅 Success badge, “Nice work!” message, leaderboard link               | Already credited            |
-| `OVERDUE`                   | Red ⏱ banner, video only, leaderboard link                             | ❌ No points                 |
+
+| **`sessionStatus`** | **Frontend UI**                                                         | **Eligibility**              |
+| ------------------- | ----------------------------------------------------------------------- | ---------------------------- |
+| `NEW` + within 1h   | Green ✅ banner, video player, “Mark as Done” button (enabled at ≥ 90%) | ✅ Counts toward leaderboard |
+| `NEW` + >1h expired | Red ⏱ banner, video only (no button)                                   | ❌ No points                 |
+| `COMPLETED`         | 🏅 Success badge, “Nice work!” message, leaderboard link                | Already credited             |
+| `OVERDUE`           | Red ⏱ banner, video only, leaderboard link                             | ❌ No points                 |
 
 ## 📡 Backend Responses & Frontend Behavior
+
 | **Response**                 | **When**                                        | **Frontend Behavior**                      | **Toast Message**                                                                                    |
 | ---------------------------- | ----------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| **200 OK + JSON**            | Session marked completed within window          | `watchedState = true`, leaderboard updated | 🟢 *“Nice Work! Video successfully marked as completed.”*                                            |
+| **200 OK + JSON**            | Session marked completed within window          | `watchedState = true`, leaderboard updated | 🟢 _“Nice Work! Video successfully marked as completed.”_                                            |
 | **204 No Content**           | Success without body (normal backend behavior)  | Handled safely, no crash                   | 🟢 Success (if in time) or ℹ️ Info (if overdue)                                                      |
-| **409 Conflict**             | Session already finished (COMPLETED or OVERDUE) | No points, still watchable                 | ℹ️ *“This session is already closed. You can still watch the video, but no points will be awarded.”* |
-| **400/401/403 Unauthorized** | Invalid/expired token                           | Error, nothing marked                      | 🔴 *“Failed to Save Progress. Unauthorized.”*                                                        |
-| **404 Not Found**            | Invalid `sessionId` or wrong account            | Error                                      | 🔴 *“Failed to Save Progress. Session not found.”*                                                   |
-| **500 Server Error**         | Unexpected backend failure                      | Error                                      | 🔴 *“Something went wrong. Please try again later.”*                                                 |
+| **409 Conflict**             | Session already finished (COMPLETED or OVERDUE) | No points, still watchable                 | ℹ️ _“This session is already closed. You can still watch the video, but no points will be awarded.”_ |
+| **400/401/403 Unauthorized** | Invalid/expired token                           | Error, nothing marked                      | 🔴 _“Failed to Save Progress. Unauthorized.”_                                                        |
+| **404 Not Found**            | Invalid `sessionId` or wrong account            | Error                                      | 🔴 _“Failed to Save Progress. Session not found.”_                                                   |
+| **500 Server Error**         | Unexpected backend failure                      | Error                                      | 🔴 _“Something went wrong. Please try again later.”_                                                 |
 
 ## ✅ QA Checklist
+
 When testing, confirm these cases:
 
 1. **Active session:** Play ≥90% → button enabled → PUT succeeds → success toast → points awarded.
@@ -66,6 +74,7 @@ When testing, confirm these cases:
 6. **Backend 500:** Shows red error toast.
 
 ## ⚠️ Notes for Developers
+
 - Do not assume JSON on all backend responses → handle 204 No Content safely.
 - Eligibility logic is enforced by backend — frontend only reflects it.
 - Toast messages are the user-facing feedback mechanism; always ensure they are clear and non-technical.

--- a/docs/flow/sessions.md
+++ b/docs/flow/sessions.md
@@ -36,46 +36,47 @@ Data returned (from SessionDto):
 
 4. Video Playback & Eligibility
    - `SmartVideoPlayer`:
-     - Checks whether current time is within 1 hour of `sessionStartTime`.
-     - Displays eligibility banner (active ✅ vs expired ⏱).
+     - Uses `sessionStatus` from the backend (`NEW`, `COMPLETED`, `OVERDUE`) as the single source of truth.
+     - If `NEW` → shows a green “active” banner with the deadline (`sessionStartTime + 1h`), enables “Mark as Done” after ≥90% watched.
+     - If `COMPLETED` → shows 🏅 success state, “Nice work!” message, leaderboard link.
+     - If `OVERDUE` → shows a red expired banner, video still playable, but no leaderboard credit.
      - Handles progress tracking via `ReactPlayer`.
-     - Requires ≥ 90% watched before enabling “Mark as Done”.
-     - Calls `PUT /sessions/{id}` to update session status when complete.
+   - Requires ≥ 90% watched before enabling “Mark as Done”.
+   - Calls `PUT /sessions/{id}` to update session status when complete.
 
 ## 🟩 Session Status & UI States
 
-| **`sessionStatus`** | **Frontend UI**                                                         | **Eligibility**              |
-| ------------------- | ----------------------------------------------------------------------- | ---------------------------- |
-| `NEW` + within 1h   | Green ✅ banner, video player, “Mark as Done” button (enabled at ≥ 90%) | ✅ Counts toward leaderboard |
-| `NEW` + >1h expired | Red ⏱ banner, video only (no button)                                   | ❌ No points                 |
-| `COMPLETED`         | 🏅 Success badge, “Nice work!” message, leaderboard link                | Already credited             |
-| `OVERDUE`           | Red ⏱ banner, video only, leaderboard link                             | ❌ No points                 |
+| **`sessionStatus`** | **Frontend UI**                                                                                              | **Eligibility**              |
+| ------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| `NEW`               | Green ✅ banner, video player, “Mark as Done” button (enabled at ≥90% watched). Shows deadline (`start+1h`). | ✅ Counts toward leaderboard |
+| `COMPLETED`         | 🏅 Success badge, “Nice work!” message, leaderboard link                                                     | Already credited             |
+| `OVERDUE`           | Red ⏱ banner, video only, leaderboard link                                                                  | ❌ No points                 |
 
 ## 📡 Backend Responses & Frontend Behavior
 
-| **Response**                 | **When**                                        | **Frontend Behavior**                      | **Toast Message**                                                                                    |
-| ---------------------------- | ----------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| **200 OK + JSON**            | Session marked completed within window          | `watchedState = true`, leaderboard updated | 🟢 _“Nice Work! Video successfully marked as completed.”_                                            |
-| **204 No Content**           | Success without body (normal backend behavior)  | Handled safely, no crash                   | 🟢 Success (if in time) or ℹ️ Info (if overdue)                                                      |
-| **409 Conflict**             | Session already finished (COMPLETED or OVERDUE) | No points, still watchable                 | ℹ️ _“This session is already closed. You can still watch the video, but no points will be awarded.”_ |
-| **400/401/403 Unauthorized** | Invalid/expired token                           | Error, nothing marked                      | 🔴 _“Failed to Save Progress. Unauthorized.”_                                                        |
-| **404 Not Found**            | Invalid `sessionId` or wrong account            | Error                                      | 🔴 _“Failed to Save Progress. Session not found.”_                                                   |
-| **500 Server Error**         | Unexpected backend failure                      | Error                                      | 🔴 _“Something went wrong. Please try again later.”_                                                 |
+| **Response**                 | **When**                                        | **Frontend Behavior**                   | **Toast Message**                                                                                    |
+| ---------------------------- | ----------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **204 No Content**           | Normal success after PUT                        | Marks session as completed, updates UI  | 🟢 _“Nice Work! Video successfully marked as completed.”_                                            |
+| **200 OK + JSON** (rare)     | Backend returns extra info                      | Used if present, fallback same as above | 🟢 Success                                                                                           |
+| **409 Conflict**             | Session already finished (COMPLETED or OVERDUE) | No points, still watchable              | ℹ️ _“This session is already closed. You can still watch the video, but no points will be awarded.”_ |
+| **400/401/403 Unauthorized** | Invalid/expired token                           | Error, nothing marked                   | 🔴 _“Failed to Save Progress. Unauthorized.”_                                                        |
+| **404 Not Found**            | Invalid `sessionId` or wrong account            | Error                                   | 🔴 _“Failed to Save Progress. Session not found.”_                                                   |
+| **500 Server Error**         | Unexpected backend failure                      | Error                                   | 🔴 _“Something went wrong. Please try again later.”_                                                 |
 
 ## ✅ QA Checklist
 
 When testing, confirm these cases:
 
 1. **Active session:** Play ≥90% → button enabled → PUT succeeds → success toast → points awarded.
-2. **Expired session (>1h late):** Red banner, video only, no “Mark as Done” button.
-3. **Completed session:** 🏅 badge + message, no button.
-4. **Overdue session (from backend):** Red banner, no button, video watchable.
+2. **Completed session:** 🏅 badge + message, no button.
+3. **Overdue session (from backend):** Red banner, no button, video watchable.
+4. **Conflict (409):** Session already finished → info toast, no points.
 5. **Invalid sessionId:** Shows error toast.
 6. **Backend 500:** Shows red error toast.
 
 ## ⚠️ Notes for Developers
-
+- Backend is the single source of truth for session state (`NEW`, `COMPLETED`, `OVERDUE`). The frontend only reflects this state and does not re-calculate expiry windows.
+- `sessionStartTime + 1h` is used purely to display a deadline to the user in the UI, not to decide eligibility.
 - Do not assume JSON on all backend responses → handle 204 No Content safely.
-- Eligibility logic is enforced by backend — frontend only reflects it.
-- Toast messages are the user-facing feedback mechanism; always ensure they are clear and non-technical.
-- Leaderboards update only when sessions are completed within the 1h window.
+- Toast messages are the user-facing feedback mechanism. Always make sure they are clear and non-technical.
+- Leaderboards update only when sessions are completed within the 1h window (backend-enforced).

--- a/docs/flow/sessions.md
+++ b/docs/flow/sessions.md
@@ -75,6 +75,7 @@ When testing, confirm these cases:
 6. **Backend 500:** Shows red error toast.
 
 ## ⚠️ Notes for Developers
+
 - Backend is the single source of truth for session state (`NEW`, `COMPLETED`, `OVERDUE`). The frontend only reflects this state and does not re-calculate expiry windows.
 - `sessionStartTime + 1h` is used purely to display a deadline to the user in the UI, not to decide eligibility.
 - Do not assume JSON on all backend responses → handle 204 No Content safely.

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -55,15 +55,11 @@ export default async function WatchPage({ params }: PageProps) {
   let sessionData: {
     sessionStartTime: string | null;
     sessionStartDisplay?: string | null;
-    sessionExecutionTime: string | null;
-    exerciseType: string | null;
     sessionStatus: string | null;
     sessionVideoUrl: string | null;
   } = {
     sessionStartTime: null,
     sessionStartDisplay: null,
-    sessionExecutionTime: null,
-    exerciseType: null,
     sessionStatus: null,
     sessionVideoUrl: null,
   };
@@ -96,19 +92,16 @@ export default async function WatchPage({ params }: PageProps) {
     sessionData = {
       sessionStartTime,
       sessionStartDisplay,
-      sessionExecutionTime: data.sessionExecutionTime ?? null,
-      exerciseType: data.exerciseType ?? null,
       sessionStatus: data.sessionStatus ?? null,
       sessionVideoUrl: data.sessionVideoUrl ?? null,
     };
 
-    // Test Data
-    /* sessionData = {
+    // Test Data (for local testing only)
+
+    /*     sessionData = {
       sessionStartTime: '2025-09-25T13:30:00.000+0200',
       sessionStartDisplay: '13:30',
-      sessionExecutionTime: null,
-      exerciseType: 'HIP',
-      sessionStatus: 'OVERDUE',
+      sessionStatus: 'OVERDUE', // try NEW, COMPLETED, OVERDUE
       sessionVideoUrl: 'https://youtu.be/-7mdU1-eEpk',
     }; */
   } catch (err) {
@@ -163,7 +156,6 @@ export default async function WatchPage({ params }: PageProps) {
                 sessionStartTime={sessionData.sessionStartTime}
                 sessionStartDisplay={sessionData.sessionStartDisplay}
                 sessionStatus={sessionData.sessionStatus}
-                sessionExecutionTime={sessionData.sessionExecutionTime}
               />
             </div>
           </div>

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -104,11 +104,11 @@ export default async function WatchPage({ params }: PageProps) {
 
     // Test Data
     /* sessionData = {
-      sessionStartTime: '10:00',
-      sessionStartDisplay: '10:00',
-      sessionExecutionTime: '2025-09-22T10:15:00.000+0200',
+      sessionStartTime: '2025-09-25T13:30:00.000+0200',
+      sessionStartDisplay: '13:30',
+      sessionExecutionTime: null,
       exerciseType: 'HIP',
-      sessionStatus: 'COMPLETED', // try OVERDUE, COMPLETED
+      sessionStatus: 'OVERDUE',
       sessionVideoUrl: 'https://youtu.be/-7mdU1-eEpk',
     }; */
   } catch (err) {


### PR DESCRIPTION
Refactors the session video flow to align fully with the backend as the single source of truth for session eligibility.
Previously, the frontend attempted to recalculate session expiry (`sessionStartTime + 1h`) itself, which caused inconsistencies. Now, the frontend simply reflects the backend sessionStatus (`NEW`, `COMPLETED`, `OVERDUE`) and uses the start time only for display purposes.

### Changes Made
- **`SmartVideoPlayer.tsx`**
  - Removed client-side expiry calculation (`isWithinOneHourWindow`) and the associated `useEffect`.
  - Banners and UI states are now driven exclusively by `sessionStatus` from the backend:
    - `NEW`: green active banner, optional deadline (`sessionStartTime + 1h`), “Mark as Done” button enabled at ≥90%.
    - `COMPLETED`: 🏅 success state with leaderboard link.
    - `OVERDUE`: red expired banner, video watchable but no leaderboard credit.
    - Invalid/missing data: warning banner.
  - Simplified state initialization (`watchedState`, `sessionOverdue`) based on backend-provided status.
  - `markAsWatched` flow updated to work safely with backend’s **204 No Content** response.

- **`page.tsx`**
  - Simplified `sessionData` to only include fields needed by `SmartVideoPlayer`:  
    `sessionStartTime`, `sessionStartDisplay`, `sessionStatus`, `sessionVideoUrl`.
  - Removed unused props (`exerciseType`, `sessionExecutionTime`).
  - Updated test data block to use ISO timestamps and backend statuses (`NEW`, `COMPLETED`, `OVERDUE`).

- **Documentation (`sessions.md`)**
  - Updated to reflect backend-driven status model:
    - Removed client-side expiry logic references.
    - Simplified Session Status & UI States table.
    - Clarified backend responses (esp. 204 No Content).
    - Reinforced that eligibility logic is backend-enforced, frontend only reflects state.